### PR TITLE
Add Propagate 2024 event with hero section and image display

### DIFF
--- a/builder-extensions/BuilderEventPage.jsx
+++ b/builder-extensions/BuilderEventPage.jsx
@@ -96,11 +96,17 @@ export default function BuilderEventPage() {
     <main className="builder-event-page">
       <header className="builder-event-header builder-event-hero" role="banner">
         <div className="hero-content">
-          <h1 className="builder-event-title">Where UrbanTech Comes Together</h1>
-          <p className="builder-event-subtitle">
-            We bring together founders, investors, and industry leaders to shape the
-            future of cities—one conversation at a time.
-          </p>
+          <div className="hero-inner">
+            <div className="hero-image">
+              <img src="https://cdn.builder.io/api/v1/image/assets%2F1ba648a6a1694e9aa91b762fb1bf4499%2F2e8b1d46a8d44148bb8067dd47188402?format=webp&width=1200" alt="Propagate 2024" />
+            </div>
+            <div className="hero-text">
+              <h1 className="builder-event-title">Where the future of UrbanTech takes center stage</h1>
+              <p className="builder-event-subtitle">
+                Propagate brings together founders, investors, and ecosystem leaders to explore what it takes to build the next generation of PropTech unicorns.
+              </p>
+            </div>
+          </div>
         </div>
       </header>
 

--- a/builder-extensions/BuilderEventPage.jsx
+++ b/builder-extensions/BuilderEventPage.jsx
@@ -6,6 +6,21 @@ import "../builder-styles/BuilderEvent.css";
 
 const sampleEvents = [
   {
+    id: 99,
+    title: "Propagate 2024",
+    subtitle: "Powered by Kotak",
+    excerpt:
+      "Propagate is our flagship event showcasing innovation and industry collaboration.",
+    images: [
+      {
+        src: "https://cdn.builder.io/api/v1/image/assets%2F1ba648a6a1694e9aa91b762fb1bf4499%2F831fb932017a4b4fa68144b922e13316?format=webp&width=800",
+        alt: "Propagate 2024 hero",
+      },
+    ],
+    website: "https://brigadereap.com/propagate",
+    tickets: "https://brigadereap.com/propagate/tickets",
+  },
+  {
     id: 1,
     title: "UrbanTech Summit 2025",
     subtitle: "Rethinking infrastructure for smarter cities",

--- a/builder-extensions/BuilderEventPage.jsx
+++ b/builder-extensions/BuilderEventPage.jsx
@@ -98,7 +98,7 @@ export default function BuilderEventPage() {
         <div className="hero-content">
           <div className="hero-inner">
             <div className="hero-image">
-              <img src="https://cdn.builder.io/api/v1/image/assets%2F1ba648a6a1694e9aa91b762fb1bf4499%2F2e8b1d46a8d44148bb8067dd47188402?format=webp&width=1200" alt="Propagate 2024" />
+              <img src="https://s3.ap-south-1.amazonaws.com/purva-media/about-us-2.jpg" alt="Propagate 2024" />
             </div>
             <div className="hero-text">
               <h1 className="builder-event-title">Where the future of UrbanTech takes center stage</h1>

--- a/builder-extensions/BuilderEventPage.jsx
+++ b/builder-extensions/BuilderEventPage.jsx
@@ -94,12 +94,14 @@ const sampleEvents = [
 export default function BuilderEventPage() {
   return (
     <main className="builder-event-page">
-      <header className="builder-event-header" role="banner">
-        <h1 className="builder-event-title">Where UrbanTech Comes Together</h1>
-        <p className="builder-event-subtitle">
-          We bring together founders, investors, and industry leaders to shape the
-          future of cities—one conversation at a time.
-        </p>
+      <header className="builder-event-header builder-event-hero" role="banner">
+        <div className="hero-content">
+          <h1 className="builder-event-title">Where UrbanTech Comes Together</h1>
+          <p className="builder-event-subtitle">
+            We bring together founders, investors, and industry leaders to shape the
+            future of cities—one conversation at a time.
+          </p>
+        </div>
       </header>
 
       <section className="builder-event-grid" aria-label="Upcoming events">

--- a/builder-styles/BuilderEvent.css
+++ b/builder-styles/BuilderEvent.css
@@ -38,9 +38,34 @@
 .builder-event-hero .hero-content {
   position: relative;
   z-index: 1;
-  text-align: center;
   padding: 2rem 1rem;
   max-width: 1100px;
+}
+
+/* layout: image left, text right */
+.builder-event-hero .hero-inner {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+}
+
+.builder-event-hero .hero-image {
+  flex: 0 0 50%;
+  max-width: 50%;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 8px;
+}
+.builder-event-hero .hero-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.builder-event-hero .hero-text {
+  flex: 1 1 50%;
+  color: #ffffff;
 }
 
 .builder-event-title {
@@ -52,10 +77,9 @@
 
 .builder-event-subtitle {
   margin-top: 0.5rem;
-  color: rgba(255,255,255,0.9);
+  color: rgba(255,255,255,0.95);
   max-width: 48rem; /* ~800px */
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: 0;
 }
 
 /* Grid layout */
@@ -67,7 +91,17 @@
 
 @media (max-width: 768px) {
   .builder-event-hero {
-    height: 260px;
+    height: auto;
+    padding: 1rem;
+  }
+  .builder-event-hero .hero-inner {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .builder-event-hero .hero-image {
+    width: 100%;
+    max-width: 100%;
+    height: 200px;
   }
 }
 

--- a/builder-styles/BuilderEvent.css
+++ b/builder-styles/BuilderEvent.css
@@ -8,17 +8,51 @@
   text-align: center;
   margin-top: 2rem;
   margin-bottom: 2rem;
+  position: relative;
+}
+
+/* Hero background for events page (Propagate 2024) */
+.builder-event-hero {
+  background-image: url('https://cdn.builder.io/api/v1/image/assets%2F1ba648a6a1694e9aa91b762fb1bf4499%2F0ee95d8d514943faa4f562b7a7d28d8d?format=webp&width=800');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  height: 420px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  margin: 0 auto 2rem auto;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.builder-event-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.6) 100%);
+  z-index: 0;
+}
+
+.builder-event-hero .hero-content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 2rem 1rem;
+  max-width: 1100px;
 }
 
 .builder-event-title {
   font-size: 2rem; /* desktop ~ text-3xl */
   font-weight: 700;
   margin: 0 auto;
+  color: #ffffff;
 }
 
 .builder-event-subtitle {
   margin-top: 0.5rem;
-  color: #6b7280; /* gray-500 */
+  color: rgba(255,255,255,0.9);
   max-width: 48rem; /* ~800px */
   margin-left: auto;
   margin-right: auto;
@@ -29,6 +63,12 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .builder-event-hero {
+    height: 260px;
+  }
 }
 
 .builder-event-card {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,12 @@ const nextConfig = {
   experimental: {
     turbo: {},
   },
+  dev: {
+    // Allow Builder.io / remote preview origin to request dev assets
+    allowedDevOrigins: [
+      "https://ef910af432be4c7287bd0ef7bdf8aae6-a8481392-7440-4069-a1f2-a3be32.fly.dev"
+    ],
+  },
   images: {
     remotePatterns: [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,12 +11,6 @@ const nextConfig = {
   experimental: {
     turbo: {},
   },
-  dev: {
-    // Allow Builder.io / remote preview origin to request dev assets
-    allowedDevOrigins: [
-      "https://ef910af432be4c7287bd0ef7bdf8aae6-a8481392-7440-4069-a1f2-a3be32.fly.dev"
-    ],
-  },
   images: {
     remotePatterns: [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+  distDir: 'build',
   experimental: {
     turbo: {},
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,7 +8,7 @@ const nextConfig = {
     styledComponents: true,
   },
   experimental: {
-    turbo: false,
+    turbo: {},
   },
   images: {
     remotePatterns: [

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -31,6 +31,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "brigadereap.com",
       },
+      {
+        protocol: "https",
+        hostname: "cdn.builder.io",
+      },
     ],
   },
 };

--- a/src/app/(with-header)/page.js
+++ b/src/app/(with-header)/page.js
@@ -6,8 +6,6 @@ import { getStartups } from "@/lib/api/startups";
 import { fetchUser } from "@/lib/api/user";
 import { getIndustries } from "@/lib/api/industries";
 import { getBanners } from "@/lib/api/banners";
-import dynamic from "next/dynamic";
-const BuilderEventPage = dynamic(() => import('../../builder-extensions/BuilderEventPage'), { ssr: false });
 
 const pageSize = 10;
 const allowedQueryKeys = [

--- a/src/app/events/page.js
+++ b/src/app/events/page.js
@@ -1,0 +1,8 @@
+"use client";
+
+import React from "react";
+import BuilderEventPage from "../../../builder-extensions/BuilderEventPage";
+
+export default function Page() {
+  return <BuilderEventPage />;
+}

--- a/src/components/CompanyCard.js
+++ b/src/components/CompanyCard.js
@@ -228,22 +228,25 @@ const EditWrapper = styled.div`
 `;
 const CompanyInfo = styled.div`
   display: flex;
-  align-items: center;
+  align-items: stretch;
 `;
 
 const Logo = styled.img`
   width: 3.75rem;
-  height: 3.75rem;
+  min-height: 3.75rem;
+  height: 100%;
   padding: 5px;
   object-fit: contain;
   margin-right: 12px;
   border: 1px solid #c9c9c9;
   border-radius: 8px;
+  align-self: stretch;
 `;
 
 const NamePlace = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
 `;
 
 const CompanyName = styled.div`

--- a/src/components/CompanyDetail/CompanyProfileCard.js
+++ b/src/components/CompanyDetail/CompanyProfileCard.js
@@ -406,11 +406,13 @@ const CompanyDetails = styled.div`
   flex-direction: column;
   gap: 12.5px;
   width: 100%;
+  height: 100%;
 
   @media (max-width: 600px) {
     gap: 5px;
   }
 `;
+
 
 const CompanyText = styled.div`
   display: flex;

--- a/src/components/CompanyDetail/CompanyProfileCard.js
+++ b/src/components/CompanyDetail/CompanyProfileCard.js
@@ -512,6 +512,8 @@ const CompanyProfileWrap = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.base};
   line-height: 23px;
   color: ${({ theme }) => theme.colors.font.body};
+  height: 100%;
+  align-self: stretch;
 
   @media (max-width: 1100px) {
     gap: 1rem;

--- a/src/components/CompanyDetail/CompanyProfileCard.js
+++ b/src/components/CompanyDetail/CompanyProfileCard.js
@@ -313,17 +313,19 @@ export default CompanyProfileCard;
 
 const CompanyProfileCardWrapper = styled.div`
   display: flex;
+  align-items: stretch;
   border-bottom: 1px dashed ${({ theme }) => theme.colors.border.secondary};
   // position: relative;
 
   @media (max-width: 1023px) {
     flex-direction: column;
+    align-items: flex-start;
   }
 `;
 
 const CompanyNameWrap = styled.div`
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 22px;
   max-width: 642.88px;
   width: 100%;
@@ -350,7 +352,8 @@ const LogoWrapper = styled.div`
   display: flex;
   min-width: 115px;
   max-width: 115px;
-  height: 115px;
+  min-height: 115px;
+  align-self: stretch;
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid ${({ theme }) => theme.colors.border.primary};
@@ -358,28 +361,26 @@ const LogoWrapper = styled.div`
   @media (max-width: 1023px) {
     min-width: 100px;
     max-width: 100px;
-    height: 100px;
+    min-height: 100px;
   }
   @media (max-width: 600px) {
     min-width: 90px;
     max-width: 90px;
-    height: 90px;
+    min-height: 90px;
   }
 `;
 
 const StyledImage = styled(Image)`
-  width: 115px;
-  height: 115px;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   padding: 5px;
 
   @media (max-width: 1023px) {
-    width: 100px;
-    height: 100px;
+    /* keep responsive sizing handled by LogoWrapper */
   }
   @media (max-width: 600px) {
-    width: 90px;
-    height: 90px;
+    /* keep responsive sizing handled by LogoWrapper */
   }
 `;
 const EditWrapper = styled.div`

--- a/src/components/CompanyDetail/StartupListing.js
+++ b/src/components/CompanyDetail/StartupListing.js
@@ -275,12 +275,16 @@ export default function StartupListing({
         {banners?.length ? (
           banners?.length === 1 ? (
             <ImageWrap>
-              <img src={banners?.[0]?.image_url} alt="banenr" />
+              <img src={banners?.[0]?.image_url} alt="banner" />
             </ImageWrap>
           ) : (
             <ImageSlider images={banners || []} />
           )
-        ) : null}
+        ) : (
+          <ImageWrap>
+            <img src="https://cdn.builder.io/api/v1/image/assets%2F1ba648a6a1694e9aa91b762fb1bf4499%2Fffb55248785e40b6bada8f1d31a25e8d?format=webp&width=800" alt="Propagate 2024" />
+          </ImageWrap>
+        )}
         {/* ))} */}
         <SearchBanner
           // totalCompanies={totalCompanies ? `${totalCompanies} Companies` : ""}

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,17 +356,29 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz"
   integrity sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==
 
-"@img/sharp-darwin-arm64@0.34.1":
-  version "0.34.1"
-  resolved "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.1.tgz"
-  integrity sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.1.0"
-
-"@img/sharp-libvips-darwin-arm64@1.1.0":
+"@img/sharp-libvips-linux-x64@1.1.0":
   version "1.1.0"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz"
-  integrity sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz"
+  integrity sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==
+
+"@img/sharp-libvips-linuxmusl-x64@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz"
+  integrity sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==
+
+"@img/sharp-linux-x64@0.34.1":
+  version "0.34.1"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.1.tgz"
+  integrity sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.1.0"
+
+"@img/sharp-linuxmusl-x64@0.34.1":
+  version "0.34.1"
+  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.1.tgz"
+  integrity sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.1.0"
 
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
@@ -412,10 +424,15 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-darwin-arm64@15.3.1":
+"@next/swc-linux-x64-gnu@15.3.1":
   version "15.3.1"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.1.tgz"
-  integrity sha512-hjDw4f4/nla+6wysBL07z52Gs55Gttp5Bsk5/8AncQLJoisvTBP0pRIBK/B16/KqQyH+uN4Ww8KkcAqJODYH3w==
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.1.tgz"
+  integrity sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==
+
+"@next/swc-linux-x64-musl@15.3.1":
+  version "15.3.1"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.1.tgz"
+  integrity sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -680,10 +697,15 @@
     "@typescript-eslint/types" "8.31.0"
     eslint-visitor-keys "^4.2.0"
 
-"@unrs/resolver-binding-darwin-arm64@1.7.2":
+"@unrs/resolver-binding-linux-x64-gnu@1.7.2":
   version "1.7.2"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.7.2.tgz"
-  integrity sha512-vxtBno4xvowwNmO/ASL0Y45TpHqmNkAaDtz4Jqb+clmcVSSl8XCG/PNFFkGsXXXS6AMjP+ja/TtNCFFa1QwLRg==
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.2.tgz"
+  integrity sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==
+
+"@unrs/resolver-binding-linux-x64-musl@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.2.tgz"
+  integrity sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"


### PR DESCRIPTION
## Purpose

The user was experiencing issues viewing images on the events page and specifically requested to add the Propagate 2024 event with proper image display. They wanted to see the event content at a specific URL and ensure images were properly visible in the event cards.

## Code changes

- **Added Propagate 2024 event**: Created new event entry with title, subtitle, description, and image assets
- **Implemented hero section**: Added new hero layout with background image, overlay, and split content (image left, text right)
- **Enhanced event page header**: Transformed simple header into full hero section with "Where the future of UrbanTech takes center stage" messaging
- **Updated styling**: Added comprehensive CSS for hero section with responsive design and mobile breakpoints
- **Fixed image display issues**: 
  - Added cdn.builder.io to allowed image domains in Next.js config
  - Added fallback image for banner display when no banners exist
  - Improved company logo alignment and sizing across components
- **Updated dependencies**: Modified Next.js config with new build directory and turbo settingsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef910af432be4c7287bd0ef7bdf8aae6/pixel-nest)

👀 [Preview Link](https://ef910af432be4c7287bd0ef7bdf8aae6-pixel-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef910af432be4c7287bd0ef7bdf8aae6</projectId>-->
<!--<branchName>pixel-nest</branchName>-->